### PR TITLE
Next version is 1.31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
-      <version>1.28</version>
+      <version>1.31</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Current github-api version is 1.31. Please release relevant version of github-api-plugin.
