### PR TITLE
set github-api to have same version as plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
-      <version>1.68</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
It can help to avoid extra commit to bump version before release

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-api-plugin/3)
<!-- Reviewable:end -->
