### PR TITLE
[JENKINS-31834] Upgrade github-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
-      <version>1.69</version>
+      <version>1.71</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
[JENKINS-31834](https://issues.jenkins-ci.org/browse/JENKINS-31834)

to [1.71](https://github.com/kohsuke/github-api/releases/tag/github-api-1.71)