### PR TITLE
Upgraded github-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   </licenses>
 
   <artifactId>github-api</artifactId>
-  <version>1.72.2-SNAPSHOT</version>
+  <version>1.75-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>GitHub API Plugin</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/GitHub+API+Plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
-      <version>1.72</version>
+      <version>1.75</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp</groupId>


### PR DESCRIPTION
We need to cut a release of this plugin including the latest release of `github-api` library.

@reviewbybees 