### PR TITLE
Use version 1.92 of the org.kohsuke.github-api artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
-      <version>1.90</version>
+      <version>1.92</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>


### PR DESCRIPTION
The version 1.90 throws an exception when parsing pull request review with the state "CHANGES_REQUESTED"

com.fasterxml.jackson.databind.exc.InvalidFormatException: Can not construct instance of org.kohsuke.github.GHPullRequestReviewState from String value ("CHANGES_REQUESTED"): value not one of declared Enum instance names: [DISMISSED, REQUEST_CHANGES, COMMENTED, PENDING, APPROVED]