### PR TITLE
Move the plugin documentation from Wiki to GitHub

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,7 +25,7 @@ Release date: (Sep 25th, 2017)
 
 Release date: (Jul 3rd, 2017)
 
-* JENKINS-45142 Retry connections which fail with `+SocketTimeoutException+`.
+* https://issues.jenkins-ci.org/browse/JENKINS-45142[JENKINS-45142] Retry connections which fail with `+SocketTimeoutException+`.
 
 === 1.85.1
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,0 +1,83 @@
+= Changelog
+
+=== Newer versions
+
+See link:https://github.com/jenkinsci/github-api-plugin/releases[GitHub Releases]
+
+=== 1.90
+
+Release date: (Nov 1, 2017)
+
+* https://issues.jenkins-ci.org/browse/JENKINS-47601[JENKINS-47601] Issues with 64bit commit status id
+* https://issues.jenkins-ci.org/browse/JENKINS-47632[JENKINS-47632] Github repo id overflowing java int
+* https://github.com/kohsuke/github-api/pull/389[PR-389] Fixed OAuth connection to enterprise API
+* https://github.com/kohsuke/github-api/pull/390[PR-390] Labels: add method to update color
+* https://github.com/kohsuke/github-api/issues/355[Issue-355] Update GHPullRequest with missing properties
+
+=== 1.89
+
+Release date: (Sep 25th, 2017)
+
+* Remove necessary transitive dependencies
+* Update to 1.89 of org.kohsuke:github-api
+
+=== 1.86
+
+Release date: (Jul 3rd, 2017)
+
+* JENKINS-45142 Retry connections which fail with `+SocketTimeoutException+`.
+
+=== 1.85.1
+
+Release date: (May 31st, 2017)
+
+* Migrated from bundling jackson2 to dependency on  to resolve class conflicts
+(https://issues.jenkins-ci.org/browse/JENKINS-44581[JENKINS-44581])
+
+=== 1.85
+
+Release date: (Mar 1st, 2017)
+
+* Updated the `+github-api+` dependency from `+1.84+` to `+1.85+`
+
+=== 1.84
+
+Release date: (Jan 10th, 2017)
+
+* Updated the `+github-api+` dependency from `+1.82+` to `+1.84+`
+
+=== 1.82
+
+Release date: (Dec 20th, 2016)
+
+* Updated the `+github-api+` dependency from `+1.80+` to `+1.82+`
+
+=== 1.80
+
+Release date: (Nov 17th, 2016)
+
+* Updated the `+github-api+` dependency from `+1.79+` to `+1.80+`
+
+=== 1.79
+
+Release date: (Oct 26th, 2016)
+
+* Updated the `+github-api+` dependency from `+1.77+` to `+1.79+`
+
+=== 1.77
+
+Release date: (Aug 10th, 2016)
+
+* Updated the `+github-api+` dependency from `+1.75+` to `+1.77+`
+
+=== 1.76
+
+Release date: (Jul 1st, 2016)
+
+* https://issues.jenkins-ci.org/browse/JENKINS-35118[JENKINS-35118] Migrate to new parent POM.
+
+=== 1.16
+
+Release date: (Jan 4th, 2012)
+
+* Initial release

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,29 @@
-# github-api-plugin
+# GitHub API Plugin for Jenkins
 
-This jenkins plugin packages stock https://github.com/kohsuke/github-api[github-api] library.
+This jenkins plugin packages the stock https://github.com/kohsuke/github-api[github-api] library.
 Normally library should be backward-compatible. 
+
+== Usage
+
+This plugin is a library plugin used by other GitHub related plugins to share the same libraries.
+This plugin does not have any user visible feature by itself.
+There's no need to install this plugin manually, although you want to keep it up to date.
+
+== Note to plugin developers
+
+If you are developing a plugin that depends on http://kohsuke.org/github-api[github-api],
+it's is highly recommended that you depend on this as opposed to bundle the jar locally.
+Doing so (as opposed to depending on `+org.kohsuke:github-api+` as a jar),
+we can eliminate the classloader problems caused by having multiple copies of github-api loaded.
+Specifically, if plugin A and B both locally includes its own copy of the `+github-api.jar+` and another plugin C depends on A and B, it'll break.
+
+== Changelog
+
+* See link:https://github.com/jenkinsci/github-api-plugin/releases[GitHub Releases] for recent plugin versions
+* For versions 1.95 and older, see the link:./CHANGELOG.adoc[Changelog]
+
+NOTE: The version number of this plugin tracks the version number of `+github-api.jar+`.
+
+== Reporting issues
+
 If you have any issues related to library please fill in https://github.com/kohsuke/github-api/issues[GH Issues]. 

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,9 @@
 # GitHub API Plugin for Jenkins
 
+image:https://img.shields.io/jenkins/plugin/v/github-api.svg[link="https://plugins.jenkins.io/github-api"]
+image:https://img.shields.io/github/release/jenkinsci/github-api-plugin.svg?label=changelog[link="https://github.com/jenkinsci/github-api-plugin/releases/latest"]
+image:https://img.shields.io/jenkins/plugin/i/github-api.svg?color=blue[link="https://plugins.jenkins.io/github-api"]
+
 This jenkins plugin packages the stock https://github.com/kohsuke/github-api[github-api] library.
 Normally library should be backward-compatible. 
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
   <name>GitHub API Plugin</name>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/GitHub+API+Plugin</url>
+  <url>https://github.com/jenkinsci/github-api-plugin</url>
 
   <properties>
     <revision>1.99</revision>


### PR DESCRIPTION
See https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/ for the context