### PR TITLE
Bump to v1.105

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,8 @@
       <version>2.7.5</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
       <version>2.10.2</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,18 @@
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
       <version>${github-api.version}</version>
+      <exclusions>
+        <!-- commons-io is provided by jenkins -->
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
+        <!-- jackson is provided by jackson2-api plugin -->
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
   <url>https://github.com/jenkinsci/github-api-plugin</url>
 
   <properties>
-    <revision>1.103</revision>
-    <github-api.version>1.103</github-api.version>
+    <revision>1.105</revision>
+    <github-api.version>1.105</github-api.version>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.164.3</jenkins.version>
     <java.level>8</java.level>

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
   <url>https://github.com/jenkinsci/github-api-plugin</url>
 
   <properties>
-    <revision>1.102</revision>
-    <github-api.version>1.102</github-api.version>
+    <revision>1.103</revision>
+    <github-api.version>1.103</github-api.version>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.150.3</jenkins.version>
     <java.level>8</java.level>
@@ -60,11 +60,25 @@
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
       <version>${github-api.version}</version>
+      <classifier>shaded</classifier>
+      <!-- The shaded jar has all non-optional dependencies included. But this is the base pom, so we need to exclude. -->
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp</groupId>
       <artifactId>okhttp-urlconnection</artifactId>
       <version>2.7.5</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.10.2</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <revision>1.103</revision>
     <github-api.version>1.103</github-api.version>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.150.3</jenkins.version>
+    <jenkins.version>2.164.3</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
   </properties>
@@ -57,28 +57,19 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+      <version>2.10.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
       <version>${github-api.version}</version>
-      <classifier>shaded</classifier>
-      <!-- The shaded jar has all non-optional dependencies included. But this is the base pom, so we need to exclude. -->
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp</groupId>
       <artifactId>okhttp-urlconnection</artifactId>
       <version>2.7.5</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>jackson2-api</artifactId>
-      <version>2.10.2</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
@kshultzCB @dwnusbaum @jglick @oleg-nenashev 

> The change adds what I've learned about shading.  In the next version of github-api we can produce a shaded jar with it's own pom, but for now this gets us the shaded jar with the project pom, from which we can exclude all dependencies. 

The change adds what I've learned about shading - don't do it.  Instead I cleaned up the dependencies to make this safe without shading. 
