### PR TITLE
/project/scm/url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <tag>${scmTag}</tag>
   </scm>
 </project>


### PR DESCRIPTION
https://ci.jenkins.io/job/Plugins/job/github-api-plugin/job/master/40/execution/node/101/log/

```
 FailRequestError: Invalid archive retrieved from Jenkins, perhaps the plugin is not properly incrementalized?
 Error: ZIP error: Error: Wrong URL in /project/scm/url from https://ci.jenkins.io/job/Plugins/job/github-api-plugin/job/master/40/artifact/**/*-rc*.637aa027bd4b/*-rc*.637aa027bd4b*/*zip*/archive.zip
     at IncrementalsPlugin.main (D:\home\site\wwwroot\incrementals-publisher\index.js:222:13)
     at process._tickCallback (internal/process/next_tick.js:68:7)
```

i.e. https://issues.jenkins-ci.org/browse/INFRA-1747 although due to https://issues.jenkins-ci.org/browse/INFRA-2544 it is not about to work anyway.