### PR TITLE
Switch to okhttp-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <url>https://github.com/jenkinsci/github-api-plugin</url>
 
   <properties>
-    <revision>1.112</revision>
+    <revision>1.111.1</revision>
     <github-api.version>1.111</github-api.version>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.164.3</jenkins.version>
@@ -35,6 +35,11 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
       <version>2.10.2</version>
+    </dependency>
+    <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>okhttp-api</artifactId>
+        <version>3.12.12.2</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>
@@ -52,11 +57,6 @@
           <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.squareup.okhttp</groupId>
-      <artifactId>okhttp-urlconnection</artifactId>
-      <version>2.7.5</version>
     </dependency>
   </dependencies>
 

--- a/src/test/java/jenkins/plugins/github/api/SmokeTest.java
+++ b/src/test/java/jenkins/plugins/github/api/SmokeTest.java
@@ -1,28 +1,74 @@
 package jenkins.plugins.github.api;
 
 import java.io.IOException;
-import java.net.URL;
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.TreeSet;
+
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.OkUrlFactory;
 import jenkins.plugins.github.api.mock.MockGitHub;
 import jenkins.plugins.github.api.mock.MockOrganization;
 import jenkins.plugins.github.api.mock.MockUser;
-import org.apache.commons.io.IOUtils;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
+import org.kohsuke.github.HttpConnector;
+import org.kohsuke.github.extras.OkHttpConnector;
+
+import javax.annotation.Nonnull;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+@RunWith(Parameterized.class)
 public class SmokeTest {
+
+    @FunctionalInterface
+    public interface IOFunction {
+        /**
+         * Applies this function to the given argument.
+         *
+         * @param t the function argument
+         * @return the function result
+         * @throws IOException if I/O error occurs
+         */
+        GitHub apply(MockGitHub t) throws IOException;
+    }
+
+    @Nonnull
+    IOFunction connectFunction;
+
+    public SmokeTest(IOFunction connectFunction) {
+        this.connectFunction = connectFunction;
+    }
+
+    @Parameterized.Parameters(name = "connectFunction={index}")
+    public static IOFunction[] connectFunctions() {
+        HttpConnector okHttpConnector = new OkHttpConnector(new OkUrlFactory(new OkHttpClient()));
+        HttpConnector okHttp3Connector = new org.kohsuke.github.extras.okhttp3.OkHttpConnector(new okhttp3.OkHttpClient());
+        ArrayList<IOFunction> list = new ArrayList<>();
+        list.add ((mock) -> GitHub.connectToEnterpriseAnonymously(mock.open()));
+        list.add ((mock) -> new GitHubBuilder().withConnector(okHttpConnector).withEndpoint(mock.open()).build());
+        list.add ((mock) -> new GitHubBuilder().withConnector(okHttp3Connector).withEndpoint(mock.open()).build());
+
+        return list.toArray(new IOFunction[] {});
+    }
+
+    public GitHub openAndConnect(MockGitHub mock) throws IOException {
+        return connectFunction.apply(mock);
+    }
+
     @Test
     public void given__veryBasicMockGitHub__when__connectingAnonymously__then__apiUrlValid() throws Exception {
         try (MockGitHub mock = new MockGitHub()) {
-            GitHub.connectToEnterpriseAnonymously(mock.open()).checkApiUrlValidity();
+            openAndConnect(mock).checkApiUrlValidity();
         }
     }
 
@@ -33,7 +79,7 @@ public class SmokeTest {
             mock.withOrg("org2").withPublicRepo("repo3");
             mock.withUser("user1").withPublicRepo("repo4").withPrivateRepo("repo5");
             Set<String> names = new TreeSet<>();
-            for (GHRepository r: GitHub.connectToEnterpriseAnonymously(mock.open()).listAllPublicRepositories()) {
+            for (GHRepository r: openAndConnect(mock).listAllPublicRepositories()) {
                 names.add(r.getFullName());
             }
             assertThat(names, contains("org1/repo1", "org2/repo3", "user1/repo4"));
@@ -51,7 +97,7 @@ public class SmokeTest {
 
             }
             Set<String> actual = new TreeSet<>();
-            for (GHRepository r: GitHub.connectToEnterpriseAnonymously(mock.open()).listAllPublicRepositories()) {
+            for (GHRepository r: openAndConnect(mock).listAllPublicRepositories()) {
                 actual.add(r.getFullName());
             }
             assertThat(actual, is(actual));
@@ -71,7 +117,7 @@ public class SmokeTest {
                     .withPrivateRepo("repo1")
                     .withPublicRepo("repo2")
                     .withPublicRepo("repo3");
-            GHUser actual = GitHub.connectToEnterpriseAnonymously(mock.open()).getUser("user1");
+            GHUser actual = openAndConnect(mock).getUser("user1");
             assertThat(actual.getLogin(), is(expected.getLogin()));
             assertThat(actual.getName(), is(expected.getName()));
             assertThat(actual.getAvatarUrl(), is(expected.getAvatarUrl()));
@@ -93,7 +139,7 @@ public class SmokeTest {
                     .withPrivateRepo("repo1")
                     .withPublicRepo("repo2")
                     .withPublicRepo("repo3");
-            GHOrganization actual = GitHub.connectToEnterpriseAnonymously(mock.open()).getOrganization("org1");
+            GHOrganization actual = openAndConnect(mock).getOrganization("org1");
             assertThat(actual.getLogin(), is(expected.getLogin()));
             assertThat(actual.getName(), is(expected.getName()));
             assertThat(actual.getAvatarUrl(), is(expected.getAvatarUrl()));


### PR DESCRIPTION
The okhttp-api plugin includes okhttp 2.7.5 and okhttp3 3.12.12.
This change unblocks migration to okhttp3 for plugins that depend on this library.

Also adds smoke tests to verify the okhttp and okhttp3 are working.