### PR TITLE
Bundle okhttp instead of plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,9 @@
     <jenkins.version>2.164.3</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
+    <okhttp.version>2.7.5</okhttp.version>
+    <okhttp3.version>3.12.12</okhttp3.version>
+    <okio.version>1.17.5</okio.version>
   </properties>
 
   <dependencies>
@@ -36,6 +39,27 @@
       <artifactId>jackson2-api</artifactId>
       <version>2.10.2</version>
     </dependency>
+    <!-- Okhttp direct dependency.  Will be replaced by okhttp-api-plugin in next release. -->
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio</artifactId>
+      <version>${okio.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>${okhttp3.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>${okhttp.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp</groupId>
+      <artifactId>okhttp-urlconnection</artifactId>
+      <version>${okhttp.version}</version>
+    </dependency>    
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
@@ -52,11 +76,6 @@
           <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.squareup.okhttp</groupId>
-      <artifactId>okhttp-urlconnection</artifactId>
-      <version>2.7.5</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,6 @@
       <version>2.10.2</version>
     </dependency>
     <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>okhttp-api</artifactId>
-        <version>3.12.12.2</version>
-    </dependency>
-    <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
       <version>${github-api.version}</version>
@@ -57,6 +52,11 @@
           <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp</groupId>
+      <artifactId>okhttp-urlconnection</artifactId>
+      <version>2.7.5</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Rolls back #51. We'll roll it forward again in the following release.