### PR TITLE
bump jenkins version to make CI green

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <properties>
     <revision>1.301</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.222.4</jenkins.version>
+    <jenkins.version>2.289.1</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
   </properties>
@@ -101,8 +101,8 @@
     <dependencies>
         <dependency>
             <groupId>io.jenkins.tools.bom</groupId>
-            <artifactId>bom-2.222.x</artifactId>
-            <version>887.vae9c8ac09ff7</version>
+            <artifactId>bom-2.289.x</artifactId>
+            <version>1246.va_b_50630c1d19</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
There might have been a bit of a race condition with the merging of #125  and #129 that is causing build failures on the main branch. Basically, the `edu.umd.cs.findbugs.annotations` package cannot be found.
Bumping the jenkins version solves this issue and makes CI green again.
This is needed for #133 and technically the other outstanding pull requests.

cc @bitwiseman  @jglick 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
