### PR TITLE
Remove deprecated `java.level` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
     <revision>1.303</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <jenkins.version>2.289.1</jenkins.version>
-    <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
   </properties>
 


### PR DESCRIPTION
The `java.level` property was deprecated in [plugin parent POM 4.40](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.40) and should be removed from this plugin's POM. In the future this warning will be changed to an error and will break the build. See https://github.com/jenkinsci/plugin-pom/pull/522 for details.