### PR TITLE
removed outdated okhttp lib, and updated java native library changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,13 +96,6 @@
       </exclusions>
     </dependency>
 
-    <!-- Included for backward compatibility, should be removed once downstream plugins are updated to use okhttp3 -->
-    <dependency>
-      <groupId>com.squareup.okhttp</groupId>
-      <artifactId>okhttp-urlconnection</artifactId>
-      <version>2.7.5</version>
-    </dependency>
-
   </dependencies>
   
   <dependencyManagement>

--- a/src/test/java/jenkins/plugins/github/api/SmokeTest.java
+++ b/src/test/java/jenkins/plugins/github/api/SmokeTest.java
@@ -5,11 +5,10 @@ import java.util.ArrayList;
 import java.util.Set;
 import java.util.TreeSet;
 
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.OkUrlFactory;
 import jenkins.plugins.github.api.mock.MockGitHub;
 import jenkins.plugins.github.api.mock.MockOrganization;
 import jenkins.plugins.github.api.mock.MockUser;
+import okhttp3.OkHttpClient;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -18,8 +17,7 @@ import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
-import org.kohsuke.github.HttpConnector;
-import org.kohsuke.github.extras.OkHttpConnector;
+import org.kohsuke.github.connector.GitHubConnector;
 import org.kohsuke.github.extras.okhttp3.OkHttpGitHubConnector;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -52,13 +50,10 @@ public class SmokeTest {
 
     @Parameterized.Parameters(name = "connectFunction={index}")
     public static IOFunction[] connectFunctions() {
-        HttpConnector okHttpConnector = new OkHttpConnector(new OkUrlFactory(new OkHttpClient()));
-        HttpConnector okHttp3Connector = new org.kohsuke.github.extras.okhttp3.OkHttpConnector(new okhttp3.OkHttpClient());
-        OkHttpGitHubConnector okHttpGitHubConnector = new OkHttpGitHubConnector(new okhttp3.OkHttpClient());
+        OkHttpClient okHttpClient = new OkHttpClient();
+        GitHubConnector okHttpGitHubConnector = new OkHttpGitHubConnector(okHttpClient);
         ArrayList<IOFunction> list = new ArrayList<>();
         list.add ((mock) -> GitHub.connectToEnterpriseAnonymously(mock.open()));
-        list.add ((mock) -> new GitHubBuilder().withConnector(okHttpConnector).withEndpoint(mock.open()).build());
-        list.add ((mock) -> new GitHubBuilder().withConnector(okHttp3Connector).withEndpoint(mock.open()).build());
         list.add ((mock) -> new GitHubBuilder().withConnector(okHttpGitHubConnector).withEndpoint(mock.open()).build());
 
         return list.toArray(new IOFunction[] {});


### PR DESCRIPTION

Changes made as per the github-api release version recommended: 
https://github.com/hub4j/github-api/releases/tag/github-api-1.300

The third party API "okhttp-urlconnection" was outdated. Need to remove the library from the github-api-plugin

**Pom.xml**
- Removed the deprecated okhttp-urlconnection dependency

**SmokeTest.java**
- Removed the deprecated classes used in the connectFunctions() method - "HttpConnector", "OkUrlFactory", "OkHttpConnector"
- Replaced the HttpConnector with GitHubConnector 
- Removed the mock test for OkHttpConnector which is deprecated.
- Creating an object for OkHttpClient and passed as param to the OkHttpGitHubConnector rather than passing param as (new OkHttpClient() ).
- Able to compile the code after making the changes with the below command as guided in the release version of github plugin

mvn -D enable-ci clean install site

Testing Done:
- By compiling the code and build success. Since, SmokeTest.java is the test file which got affected.

![Okhttp_Compilation_Status](https://github.com/jenkinsci/github-api-plugin/assets/142486073/79b53e46-6984-42fa-8395-1840555b89ad)




<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
