### PR TITLE
Use GitHub API 1.321

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
 - package-ecosystem: maven
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: /
   schedule:
-    interval: daily
+    interval: monthly

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.7</version>
+    <version>1.8</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.75</version>
+    <version>4.81</version>
     <relativePath />
   </parent>
   

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
   <properties>
-    <revision>1.318</revision>
+    <revision>1.321</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <jenkins.version>2.361.4</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,6 @@
     </dependencies>
   </dependencyManagement>
 
-  <!-- get every artifact through maven.glassfish.org, which proxies all the artifacts that we need -->
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>


### PR DESCRIPTION
## Use GitHub API 1.321

Use the most recent release of the GitHub API, 1.321.

Also includes other updates to make the plugin use more recent dependencies.

- Use parent pom 4.81
- Remove incorrect comment about glassfish repository
- Check dependencies monthly
- Bump git-changelist-maven-extension from 1.7 to 1.8.

Replaces pull request:

* #240

### Testing done

Incremental build tested with plugin bill of materials successfully.

Tested with regular use in [my Jenkins controller](https://github.com/MarkEWaite/docker-lfs/blob/2f998fe14a4e7e7b8fbd0364a1e5940685754177/plugins.txt#L60) and found no issues.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
