### PR TITLE
[JENKINS-73132] Adapt GitHub API for Jetty 12 (EE 8)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(useContainerAgent: true, configurations: [
   [platform: 'linux', jdk: 21],
   [platform: 'linux', jdk: 17],
-  [platform: 'windows', jdk: 11],
+  [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,13 @@
   <properties>
     <revision>1.321</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.361.4</jenkins.version>
+    <!-- TODO JENKINS-73130 https://ci.jenkins.io/job/Core/job/jenkins/job/prototype/ -->
+    <jenkins.version>2.468-rc35110.010999645350</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <no-test-jar>false</no-test-jar>
+    <!-- TODO JENKINS-73339 until in parent POM -->
+    <jenkins-test-harness.version>2244.v77428109fd1f</jenkins-test-harness.version>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/src/test/java/jenkins/plugins/github/api/mock/MockGitHub.java
+++ b/src/test/java/jenkins/plugins/github/api/mock/MockGitHub.java
@@ -27,7 +27,7 @@ import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee8.servlet.ServletContextHandler;
 import org.jvnet.hudson.test.ThreadPoolImpl;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;


### PR DESCRIPTION
See [JENKINS-73132](https://issues.jenkins.io/browse/JENKINS-73132). This PR is on hold until [JENKINS-73130](https://issues.jenkins.io/browse/JENKINS-73130) is merged and released.