### PR TITLE
[JENKINS-73132] Adapt GitHub API for Jetty 12 (EE 8)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
   [platform: 'linux', jdk: 21],
-  [platform: 'linux', jdk: 17],
-  [platform: 'windows', jdk: 11],
+  [platform: 'windows', jdk: 17],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
   [platform: 'linux', jdk: 21],
-  [platform: 'windows', jdk: 17],
+  [platform: 'windows', jdk: 17]
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <properties>
     <revision>1.321</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.472-rc35224.f615612a_1850</jenkins.version>
+    <jenkins.version>2.472</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <no-test-jar>false</no-test-jar>
     <!-- TODO JENKINS-73339 until in parent POM -->

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
   <properties>
     <revision>1.321</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.baseline>2.462</jenkins.baseline>
     <jenkins.version>2.472</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <no-test-jar>false</no-test-jar>
@@ -106,7 +105,7 @@
     <dependencies>
         <dependency>
             <groupId>io.jenkins.tools.bom</groupId>
-            <artifactId>bom-${jenkins.baseline}.x</artifactId>
+            <artifactId>bom-weekly</artifactId>
             <version>3258.vcdcf15936a_fd</version>
             <scope>import</scope>
             <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,12 @@
   <properties>
     <revision>1.321</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.472-rc35224.f615612a_1850</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <no-test-jar>false</no-test-jar>
+    <!-- TODO JENKINS-73339 until in parent POM -->
+    <jenkins-test-harness.version>2250.v03a_1295b_0a_30</jenkins-test-harness.version>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
   <properties>
     <revision>1.321</revision>
     <changelist>999999-SNAPSHOT</changelist>
+    <jenkins.baseline>2.462</jenkins.baseline>
     <jenkins.version>2.472</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <no-test-jar>false</no-test-jar>
@@ -105,8 +106,8 @@
     <dependencies>
         <dependency>
             <groupId>io.jenkins.tools.bom</groupId>
-            <artifactId>bom-2.361.x</artifactId>
-            <version>2102.v854b_fec19c92</version>
+            <artifactId>bom-${jenkins.baseline}.x</artifactId>
+            <version>3258.vcdcf15936a_fd</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/src/test/java/jenkins/plugins/github/api/mock/MockGitHub.java
+++ b/src/test/java/jenkins/plugins/github/api/mock/MockGitHub.java
@@ -27,7 +27,7 @@ import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee8.servlet.ServletContextHandler;
 import org.jvnet.hudson.test.ThreadPoolImpl;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;


### PR DESCRIPTION
The goal was to adapt the changes for Jetty 12 EE 8 for `github-api-plugin` see https://issues.jenkins.io/browse/JENKINS-73132. 

Also fixed the UT failures.

Closes #242.

### Testing done
All tests are passing locally with `2.472-rc35224.f615612a_1850` as a `2.472`(which is not yet released). 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
